### PR TITLE
feat(cli): support custom mount element id via html.mountId

### DIFF
--- a/packages/cli/src/types/config.ts
+++ b/packages/cli/src/types/config.ts
@@ -223,6 +223,11 @@ export interface HtmlType extends HtmlRspackPluginOptions {
    */
   favicon?: string
   /**
+   * 自定义挂载节点的 id，默认为 'emp-root'
+   * @default 'emp-root'
+   */
+  mountId?: string
+  /**
    * 网站语言
    */
   lang?: string

--- a/packages/cli/template/index.html
+++ b/packages/cli/template/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <div id="emp-root"></div>
+  <div id="<%= htmlWebpackPlugin.options.mountId || 'emp-root' %>"></div>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Add `mountId` option to `HtmlType` config, allowing users to customize the mount container id in the generated HTML
- Default value remains `emp-root` for full backward compatibility
- When set, the default template renders `<div id="<custom-id>">` instead of `<div id="emp-root">`

## Usage

```ts
// emp.config.ts
export default defineConfig({
  html: {
    mountId: 'my-app', // generates <div id="my-app"></div>
  },
})
```

## Motivation

In some scenarios (e.g., micro-frontend integration, multiple EMP apps on the same page), the default `emp-root` id may conflict. This option gives users the flexibility to specify a custom mount point without needing to provide a full custom HTML template.

## Changes
- `packages/cli/template/index.html` — use `htmlWebpackPlugin.options.mountId` with `emp-root` as fallback
- `packages/cli/src/types/config.ts` — add `mountId` field to `HtmlType` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)