### PR TITLE
fix(cli): 升级 glob 安全补丁

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -124,7 +124,7 @@
     "cors": "2.8.6",
     "default-gateway": "7.2.2",
     "fs-extra": "11.3.6",
-    "glob": "11.0.3",
+    "glob": "11.1.0",
     "gzip-size": "7.0.0",
     "html-webpack-plugin": "5.6.7",
     "http-proxy-middleware": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,8 +574,8 @@ importers:
         specifier: 11.3.6
         version: 11.3.6
       glob:
-        specifier: 11.0.3
-        version: 11.0.3
+        specifier: 11.1.0
+        version: 11.1.0
       gzip-size:
         specifier: 7.0.0
         version: 7.0.0
@@ -4964,9 +4964,10 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -11719,7 +11720,7 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.3:
+  glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3


### PR DESCRIPTION
## 背景

`@empjs/cli` 直接依赖 `glob@11.0.3`。生产依赖审计确认其处于高危命令注入漏洞范围（`>=11.0.0 <11.1.0`）。

## 证据

- `corepack pnpm audit --prod --json` 在变更前定位到 `packages__cli>glob`；补丁版本要求为 `>=11.1.0`。
- 变更后该 `glob` advisory 已为 0，生产审计高危数量由 12 降为 11。

## 改动

- 将 `@empjs/cli` 的直接依赖从 `glob@11.0.3` 升至同主版本补丁 `11.1.0`。
- 同步 `pnpm-lock.yaml`。

## 范围与风险

- 仅修改 `packages/cli/package.json` 和锁文件；未触及 `apps/**`、`website/**`、发布工作流或公共 API。
- `glob@11.1.0` 本身仍带上游 deprecated 元数据；本 PR 的目标是修复已确认的命令注入版本范围，不进行大版本迁移。

## 验证

- [x] `corepack pnpm workflow:check`
- [x] `corepack pnpm ci:verify`
- [x] `corepack pnpm empbuild`
- [x] `corepack pnpm audit --prod --json`（目标 advisory 清零）
- [x] `code-review-graph update/detect-changes/impact`（无受影响代码节点或额外文件）
- [x] `git diff --cached --check`

## 关联 Issue

无：这是证据充分、向后兼容的直接安全补丁，不需要额外产品或 API 决策。

## 回滚方式

回滚本 PR 的单个提交 `147609ad`，即可恢复先前锁定版本。

## 目录边界

- [x] 未修改 `apps/**`、`website/**`、`packages/cdn-*` 或 `packages/lib-*`。
- [x] 未提交生成产物、缓存或本地图索引。
- [x] 未修改发布流程，未执行发布或自动合并。