### PR TITLE
chore(test): 升级 Playwright 至 1.62.0

### DIFF
--- a/apps/test/apps.rules.test.ts
+++ b/apps/test/apps.rules.test.ts
@@ -362,6 +362,6 @@ describe('legacy apps rules coverage', () => {
     expect(workflowGuard).toContain('packages/emp-share/test/browser')
     expect(workflowGuard).toContain('test:apps:browser')
     expect(rootPackage.devDependencies?.['@rstest/browser']).toBe('0.11.4')
-    expect(rootPackage.devDependencies?.playwright).toBe('1.61.1')
+    expect(rootPackage.devDependencies?.playwright).toBe('1.62.0')
   })
 })

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@rstest/core": "0.11.4",
     "@types/node": "^24.9.2",
     "cross-env": "^7.0.3",
-    "playwright": "1.61.1",
+    "playwright": "1.62.0",
     "typescript": "7.0.2"
   },
   "packageManager": "pnpm@10.33.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 0.23.2(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@7.0.2)
       '@rstest/browser':
         specifier: 0.11.4
-        version: 0.11.4(@rstest/core@0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0))(playwright@1.61.1)
+        version: 0.11.4(@rstest/core@0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0))(playwright@1.62.0)
       '@rstest/core':
         specifier: 0.11.4
         version: 0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
@@ -30,8 +30,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       playwright:
-        specifier: 1.61.1
-        version: 1.61.1
+        specifier: 1.62.0
+        version: 1.62.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -5989,14 +5989,14 @@ packages:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -9202,7 +9202,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rstest/browser@0.11.4(@rstest/core@0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0))(playwright@1.61.1)':
+  '@rstest/browser@0.11.4(@rstest/core@0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0))(playwright@1.62.0)':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@rstest/core': 0.11.4(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)
@@ -9212,7 +9212,7 @@ snapshots:
       sirv: 3.0.2
       ws: 8.21.1
     optionalDependencies:
-      playwright: 1.61.1
+      playwright: 1.62.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12701,11 +12701,11 @@ snapshots:
     dependencies:
       find-up: 6.3.0
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.0: {}
 
-  playwright@1.61.1:
+  playwright@1.62.0:
     dependencies:
-      playwright-core: 1.61.1
+      playwright-core: 1.62.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## 背景与证据

- 实时依赖核验显示 Playwright 1.62.0 已发布，EMP 仍固定在 1.61.1。
- `@rstest/browser@0.11.4` 的 peer 范围为 `^1.49.1`，覆盖 1.62.0；仓库 Node 范围与 Playwright `>=20` 相容。

## 改动

- 根工作区 Playwright 升级至 1.62.0，并更新锁文件。
- 同步 apps 规则测试中的版本契约。

## 范围与风险

- 未触及发布工作流、`packages/cdn-*`、`packages/lib-*` 或生成物。
- 仅升级浏览器测试工具及其 Chromium 运行时，仍需由各平台 CI 覆盖其自身浏览器环境。

## 验证

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm workflow:check`
- `corepack pnpm ci:verify`
- `corepack pnpm empbuild`
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/... corepack pnpm test:apps:browser`（19 文件、23 用例通过）
- `git diff --check`
- code-review-graph build/update/detect-changes/impact：3 个改动文件、0 个受影响执行流、0 个测试缺口、风险分 0.30。
- 独立只读审查：未发现 P0/P1 阻断问题。

## 关联

- 无需关联 Issue。

## 回滚

- 回滚本 PR 的单个提交即可恢复 Playwright 1.61.1 锁图。
