### PR TITLE
fix(security): 修复 CLI glob 传递依赖

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3920,9 +3920,9 @@ packages:
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5664,8 +5664,8 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
@@ -10719,7 +10719,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11732,7 +11732,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
@@ -12380,9 +12380,9 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
## 背景

`corepack pnpm audit --json` 命中 `GHSA-mh99-v99m-4gvg`（CVE-2026-14257，CVSS 7.5）：`packages/cli > glob@11.1.0 > minimatch@10.2.5 > brace-expansion@5.0.6`。该链存在 brace pattern 导致 Node 进程 OOM 的风险。

## 改动

- 仅更新 `pnpm-lock.yaml`：`minimatch` `10.2.5` → `10.2.6`。
- 仅更新该链的 `brace-expansion` `5.0.6` → `5.0.8`。
- 不修改 `packages/cli` 的直接依赖声明，不引入 overrides。
- Stylus 与 ESLint 的旧传递链保持不变，留待 Issue #414 后续分链路评估。

## 证据与风险

- `pnpm why` 确认 CLI 直接 glob 链使用 `minimatch@10.2.6` / `brace-expansion@5.0.8`。
- npm registry 元数据中的版本、integrity、engines 与锁文件一致。
- 更新后审计由 20 high 降为 18 high；剩余命中属于未授权处理的历史链，不作为本 PR 的阻断。
- 新 `brace-expansion` 要求 Node 20 或更高版本，与仓库 Node engine 范围一致。

## 验证

- `corepack pnpm install --frozen-lockfile --ignore-scripts`：通过
- `corepack pnpm workflow:check`：通过
- `corepack pnpm test:cli`：13 个文件、80 个测试全部通过
- `corepack pnpm ci:verify`：通过
- `corepack pnpm empbuild`：通过
- code-review-graph build/update、detect-changes、impact：仅锁文件变更，风险 0.00，无受影响流程或测试缺口
- 独立只读 reviewer：未发现 P0/P1/P2 阻断问题

## 范围与回滚

未触及 `apps/**`、网站、发布工作流或生成物。需要回滚时可还原提交 `204bf41b`。

关联 Issue：#414