### PR TITLE
fix(security): 修复 CLI glob 的 brace-expansion 风险

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3920,8 +3920,8 @@ packages:
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -5583,8 +5583,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.5.1:
-    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@4.1.5:
@@ -10719,7 +10719,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12302,7 +12302,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.5.1: {}
+  lru-cache@11.5.2: {}
 
   lru-cache@4.1.5:
     dependencies:
@@ -12382,7 +12382,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.2:
     dependencies:
@@ -12650,7 +12650,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   path-type@4.0.0: {}


### PR DESCRIPTION
## 背景

npm 审计新增 `GHSA-rgw5-rvv9-x895`：`packages/cli → glob@11.1.0 → minimatch@10.2.6 → brace-expansion@5.0.8` 仍受影响；修复版本为 `>=5.0.9`。该路径属于已由 #416 确认的 CLI glob 链。

## 改动

- 仅更新 `pnpm-lock.yaml`：`brace-expansion 5.0.8 → 5.0.9`；随同一 `glob → path-scurry` 闭包刷新 `lru-cache 11.5.1 → 11.5.2`。
- 未修改 manifest、公开 API、配置或发布工作流。

## 验证

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm workflow:check`
- `corepack pnpm ci:verify`
- `corepack pnpm empbuild`
- `corepack pnpm audit --prod --json`：high `24 → 23`，移除上述 `brace-expansion@5` 高危路径。
- code-review-graph：1 个变更文件、0 源码节点、0 受影响流程、0 测试缺口，风险 0.00。

## 风险与回滚

其余 high 风险来自 Stylus、ESLint、Vue2、Rsdoctor 等独立链，仍由 #414 跟踪。若出现解析/构建回归，revert 本 PR 的单一锁文件提交即可。

关联 Issue: #414
