### PR TITLE
fix(security): 修复 sass immutable 传递依赖风险

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5131,8 +5131,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  immutable@5.1.6:
-    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -11902,7 +11902,7 @@ snapshots:
   image-size@0.5.5:
     optional: true
 
-  immutable@5.1.6: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -13087,7 +13087,7 @@ snapshots:
       '@bufbuild/protobuf': 2.12.0
       buffer-builder: 0.2.0
       colorjs.io: 0.5.2
-      immutable: 5.1.6
+      immutable: 5.1.9
       rxjs: 7.8.2
       supports-color: 8.1.1
       sync-child-process: 1.0.2
@@ -13122,7 +13122,7 @@ snapshots:
   sass@1.101.0:
     dependencies:
       chokidar: 5.0.0
-      immutable: 5.1.6
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
@@ -13130,7 +13130,7 @@ snapshots:
   sass@1.93.2:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.6
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## 背景

Issue #414 跟踪的 CLI 生产依赖链 `sass-embedded@1.93.2 → immutable@5.1.6` 命中 Immutable.js 两项 DoS advisory，修复版本为 `>=5.1.8`。

## 改动

- 仅更新 `pnpm-lock.yaml`：`immutable@5.1.6 → 5.1.9`。
- 同步 `sass-embedded@1.93.2`、`sass@1.101.0`、`sass@1.93.2` 的 snapshot 引用。
- `immutable@5.1.9` 在现有 `^5.0.2`/`^5.1.5` 范围内；未修改 manifest、Sass 主版本、公开 API 或发布工作流。

## 证据与风险

- registry version、integrity、tarball 与 lockfile 一致；`pnpm why immutable` 仅解析一个版本 `5.1.9`。
- 目标 CLI audit finding 已清零；生产 high 从 14 降至 12。
- 剩余 high 为其他独立链，由 Issue #414 跟踪。

## 验证

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm workflow:check`
- `corepack pnpm ci:verify`
- `corepack pnpm empbuild`
- immutable、sass-embedded、sass runtime smoke
- `corepack pnpm audit --prod --json`（整体因其他 advisory 返回非零；目标路径无 finding）
- code-review-graph：1 个锁文件、0 源码节点、0 受影响流程、0 测试缺口、风险 0.00

## 回滚

单一锁文件提交可直接 revert。

关联 Issue：#414

未触及受保护的 apps、website、packages/cdn-*、packages/lib-* 与发布工作流。