### PR TITLE
chore(cli): 升级 Rspack dev-server 至 2.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -113,7 +113,7 @@
     "@empjs/chain": "workspace:*",
     "@rsdoctor/rspack-plugin": "1.5.18",
     "@rspack/core": "2.1.5",
-    "@rspack/dev-server": "^2.1.0",
+    "@rspack/dev-server": "^2.2.0",
     "@swc/helpers": "^0.5.23",
     "address": "^2.0.2",
     "chalk": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,8 +541,8 @@ importers:
         specifier: 2.1.5
         version: 2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
-        specifier: ^2.1.0
-        version: 2.1.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        specifier: ^2.2.0
+        version: 2.2.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
       '@swc/helpers':
         specifier: ^0.5.23
         version: 0.5.23
@@ -2578,8 +2578,8 @@ packages:
       '@rspack/core':
         optional: true
 
-  '@rspack/dev-server@2.1.0':
-    resolution: {integrity: sha512-WkCi6bWThVX5Ziv04srPaRoCoUY5FJolO4gqzE7xPO0XbXShsGnwn0vGD0DFfnYFcw9VSsxlmeCDV799lNYclA==}
+  '@rspack/dev-server@2.2.0':
+    resolution: {integrity: sha512-Bd0DNphOJ5/KAm3bFpUUZeP7O6jvVDNdXJEmlpsVZLfdSgjmrd6Ut/EHCBv95tmiwOQN0M41SdvlUU4f855HFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rspack/core': ^2.0.0
@@ -9115,7 +9115,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspack/dev-server@2.1.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
+  '@rspack/dev-server@2.2.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@rspack/dev-middleware': 2.0.3(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))

--- a/test/toolchain.rules.test.ts
+++ b/test/toolchain.rules.test.ts
@@ -223,14 +223,14 @@ describe('toolchain version contract', () => {
     expect(lockfile).not.toContain('@rspack/core@2.0.8')
   })
 
-  test('cli depends on the current Rspack 2.1 latest and TS7-aware tooling', () => {
+  test('cli depends on the current Rspack core and dev-server stack with TS7-aware tooling', () => {
     const cliPkg = readJson('packages/cli/package.json')
     const reactPkg = readJson('packages/plugin-react/package.json')
     const cliRstestConfig = readText('packages/cli/rstest.config.ts')
     const lockfile = readText('pnpm-lock.yaml')
 
     expect(cliPkg.dependencies['@rspack/core']).toBe('2.1.5')
-    expect(cliPkg.dependencies['@rspack/dev-server']).toBe('^2.1.0')
+    expect(cliPkg.dependencies['@rspack/dev-server']).toBe('^2.2.0')
     expect(reactPkg.dependencies['@rspack/plugin-react-refresh']).toBe('^2.0.2')
     expect(cliPkg.dependencies['@swc/helpers']).toBe('^0.5.23')
     expect(cliPkg.dependencies['@rsdoctor/rspack-plugin']).toBe('1.5.18')
@@ -240,6 +240,7 @@ describe('toolchain version contract', () => {
     expect(cliPkg.dependencies['ts-checker-rspack-plugin']).toBe('^1.5.2')
     expect(cliPkg.devDependencies['@vue/tsconfig']).toBe('^0.9.1')
     expect(lockfile).toContain('@rsdoctor/rspack-plugin@1.5.18')
+    expect(lockfile).toContain('@rspack/dev-server@2.2.0')
     expect(lockfile).toContain('ts-checker-rspack-plugin@1.5.2')
     expect(lockfile).not.toContain('@rsdoctor/rspack-plugin@1.5.17')
     expect(lockfile).not.toContain('ts-checker-rspack-plugin@1.5.1')


### PR DESCRIPTION
## 背景

核心依赖扫描在 `@rspack/dev-server` 发现稳定版 `2.2.0`，当前为 `2.1.0`，候选进入 EVALUATE（critical / dev-server）。上游 v2.2.0 发布说明仅涉及默认 HPM 日志降噪、测试稳定性和依赖更新；Node 与 peerDependencies 未变化。

## 改动

- 将 `packages/cli` 的 `@rspack/dev-server` 范围更新为 `^2.2.0`。
- 锁定 `@rspack/dev-server@2.2.0` 及官方 registry integrity；`@rspack/core@2.1.5`、`@rspack/dev-middleware@2.0.3` 保持不变。
- 更新 toolchain contract，防止 manifest/lockfile 版本漂移。

## 范围与风险

- 未修改公开 API、运行时代码、发布工作流、apps/website 或 Netlify（已退役）。
- 回滚方式：revert 本 PR 提交 `93dcdb240f8e53941e7ee6d20722ea2571813571`，或将直接依赖恢复到 `^2.1.0` 后重新生成锁文件。
- 关联 Issue：无；本项为核心依赖扫描 EVALUATE 候选的独立闭环。

## 验证

- `corepack pnpm install --frozen-lockfile --ignore-scripts`：通过。
- `corepack pnpm test:toolchain`：12/12 通过。
- `corepack pnpm --filter @empjs/chain build && corepack pnpm --filter @empjs/cli test`：通过。
- 真实 Rspack + dev-server smoke：编译成功，`/bundle.js` HTTP 200，内容断言通过。
- `corepack pnpm workflow:check`：通过。
- `corepack pnpm ci:verify`：49/49 通过。
- `corepack pnpm empbuild`：通过。
- 生产 audit：12 high / 18 moderate / 2 low / 0 critical；无 `@rspack/dev-server` 相关 finding，现存风险未被本 PR 掩盖。

## code-review-graph

- full build：439 files / 2,426 nodes / 15,512 edges。
- update：11 files，0 nodes/edges（依赖与测试契约变更）。
- detect-changes：3 changed files，0 affected flows，0 test gaps，risk 0.30。
- impact：19 direct nodes，100 nodes within 2 hops，31 files affected（CLI 输出截断 100/551）。
- flow `setup`（id 4）：28 nodes，depth 4，criticality 0.6989；未发现本次变更影响的执行流。
- `tests_for` 查询 dev-server 运行时代码未返回静态关联；仓库 CLI watch/serve real acceptance 与本轮真实 smoke 已覆盖启动、编译、HTTP 服务。

## 保护范围

未触碰 `apps/**`、`website`、发布工作流、生成物、缓存或其他用户改动。
